### PR TITLE
Add a sanety check

### DIFF
--- a/analysis.ipynb
+++ b/analysis.ipynb
@@ -330,6 +330,8 @@
     "# if diff is negative unity data was received before eeg\n",
     "if diff < 0:\n",
     "    print(\"Unity data received first ✗\")\n",
+    "    if diff < -0.98: #so if the difference cannot be explained by normal EEG sampling",
+    "        print(\"Something went wrong with this recording\")",
     "else:\n",
     "    print(\"EEG data received first ✔\")"
    ]


### PR DESCRIPTION
Should Unity be sampled before EEG, is the distance explainable by the normal sampling rate of EEG